### PR TITLE
Modify comment to reference cca

### DIFF
--- a/internal/types.go
+++ b/internal/types.go
@@ -1,4 +1,4 @@
-// Package internal contains the core types and logic for ccAgents.
+// Package internal contains the core types and logic for cca.
 package internal
 
 // Issue represents a GitHub issue fetched via the GitHub CLI


### PR DESCRIPTION
## Summary
- update comment in internal/types.go to mention cca

## Testing
- `go build ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_683f622737e88328bc5e946884b2f33f