### PR TITLE
Add progress indicator for Claude calls

### DIFF
--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,0 +1,15 @@
+export async function withProgress<T>(
+  label: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  let count = 0;
+  const id = setInterval(() => {
+    count++;
+    console.log(`${label}... ${count}`);
+  }, 1000);
+  try {
+    return await action();
+  } finally {
+    clearInterval(id);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `withProgress` helper to show progress
- use the helper when generating code and fixing with Claude

## Testing
- `deno lint src/main.ts src/processor.ts src/git.ts src/types.ts src/progress.ts tests/processor.test.ts`
- `deno test --allow-all` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_683fcb22439c832893597ef089e56883